### PR TITLE
Remove unused expense list

### DIFF
--- a/src/ExpenseTrackerGUI.java
+++ b/src/ExpenseTrackerGUI.java
@@ -101,16 +101,13 @@ class UtilityExpense extends Expense {
 
 // ExpenseManager class
 class ExpenseManager {
-    private ArrayList<Expense> expenses;
     private ExpenseDAO expenseDAO;
 
     public ExpenseManager() {
-        this.expenses = new ArrayList<>();
         this.expenseDAO = new ExpenseDAO();
     }
 
     public void addExpense(Expense exp) {
-        expenses.add(exp);
         expenseDAO.insertExpense(exp);
     }
 
@@ -120,7 +117,7 @@ class ExpenseManager {
 
     public double getTotalExpenses() {
         double total = 0;
-        for (Expense exp : expenseDAO.getAllExpenses()) {
+        for (Expense exp : getExpenses()) {
             total += exp.getAmount();
         }
         return total;


### PR DESCRIPTION
## Summary
- refactor `ExpenseManager` to use only the DAO for expense totals
- remove redundant `expenses` list

## Testing
- `./scripts/clean.sh`
- `javac -d bin -cp sqlite-jdbc-3.50.1.0.jar src/*.java`


------
https://chatgpt.com/codex/tasks/task_e_6847727fbc708321bc8b5c3cafa06f14